### PR TITLE
Refactor RemapperTransformer to support preserving package structure

### DIFF
--- a/deobfuscator-impl/src/test/java/uwu/narumi/deobfuscator/TestDeobfuscation.java
+++ b/deobfuscator-impl/src/test/java/uwu/narumi/deobfuscator/TestDeobfuscation.java
@@ -53,6 +53,11 @@ public class TestDeobfuscation extends TestDeobfuscationBase {
         .transformers(RemapperTransformer::new)
         .input(OutputType.MULTIPLE_CLASSES, InputType.JAVA_CODE, "remap")
         .register();
+    test("Remapper - Preserve Packages")
+        .transformers(() -> new RemapperTransformer(true))
+        .input(OutputType.MULTIPLE_CLASSES, InputType.JAVA_CODE, "remappreserve")
+        // Decompilation is enabled by default, will compare against results in testData/results/java/remappreserve
+        .register();
 
     // Test sandbox security (e.g. not allowing dangerous calls)
     test("Sandbox security")

--- a/testData/results/java/remappreserve/remappreserve/class_0.dec
+++ b/testData/results/java/remappreserve/remappreserve/class_0.dec
@@ -1,0 +1,14 @@
+package remappreserve;
+
+import remappreserve.nes.ted.class_2;
+
+public class class_0 {
+    public void method_0() {
+        System.out.println("AnotherInMain running...");
+        class_1 mc = new class_1();
+        mc.method_1();
+        class_2 dnc = new class_2();
+        mc.method_2(dnc);
+        dnc.method_3();
+    }
+}

--- a/testData/results/java/remappreserve/remappreserve/class_1.dec
+++ b/testData/results/java/remappreserve/remappreserve/class_1.dec
@@ -1,0 +1,15 @@
+package remappreserve;
+
+import remappreserve.nes.ted.class_2;
+
+public class class_1 {
+    public static String field_0 = "Hello from MainClass";
+
+    public void method_1() {
+        System.out.println(field_0);
+    }
+
+    public void method_2(class_2 dnc) {
+        dnc.method_3();
+    }
+}

--- a/testData/results/java/remappreserve/remappreserve/nes/ted/class_2.dec
+++ b/testData/results/java/remappreserve/remappreserve/nes/ted/class_2.dec
@@ -1,0 +1,11 @@
+package remappreserve.nes.ted;
+
+import remappreserve.class_1;
+
+public class class_2 {
+    public void method_3() {
+        System.out.println("DeeplyNestedClass reporting in!");
+        System.out.println("Accessing MainClass: " + class_1.field_0);
+        new class_1().method_1();
+    }
+}

--- a/testData/src/java/src/main/java/remappreserve/AnotherInMain.java
+++ b/testData/src/java/src/main/java/remappreserve/AnotherInMain.java
@@ -1,0 +1,15 @@
+package remappreserve;
+
+import remappreserve.nes.ted.DeeplyNestedClass;
+
+public class AnotherInMain {
+    public void run() {
+        System.out.println("AnotherInMain running...");
+        MainClass mc = new MainClass();
+        mc.printGreeting();
+
+        DeeplyNestedClass dnc = new DeeplyNestedClass();
+        mc.callNested(dnc);
+        dnc.doSomething();
+    }
+}

--- a/testData/src/java/src/main/java/remappreserve/MainClass.java
+++ b/testData/src/java/src/main/java/remappreserve/MainClass.java
@@ -1,0 +1,13 @@
+package remappreserve;
+
+public class MainClass {
+    public static String GREETING = "Hello from MainClass";
+
+    public void printGreeting() {
+        System.out.println(GREETING);
+    }
+
+    public void callNested(remappreserve.nes.ted.DeeplyNestedClass dnc) {
+        dnc.doSomething();
+    }
+}

--- a/testData/src/java/src/main/java/remappreserve/nes/ted/DeeplyNestedClass.java
+++ b/testData/src/java/src/main/java/remappreserve/nes/ted/DeeplyNestedClass.java
@@ -1,0 +1,11 @@
+package remappreserve.nes.ted;
+
+import remappreserve.MainClass;
+
+public class DeeplyNestedClass {
+    public void doSomething() {
+        System.out.println("DeeplyNestedClass reporting in!");
+        System.out.println("Accessing MainClass: " + MainClass.GREETING);
+        new MainClass().printGreeting();
+    }
+}


### PR DESCRIPTION
Added a `preservePackages` option to the RemapperTransformer.
- When `true`, class files retain their original package directory structure, while the simple class name is remapped (e.g., `original/pkg/ClassA` -> `original/pkg/class_0`).
- When `false` (default), the existing behavior of flattening packages and renaming classes is maintained (e.g., `original/pkg/ClassA` -> `class_0`).

Updated RemapperTransformer with the new option and modified constructors and class name mapping logic accordingly.

Added new test data under `testData/src/java/src/main/java/remappreserve/` with nested packages to test the new functionality. Added a new test case `Remapper - Preserve Packages` in `TestDeobfuscation.java` that uses this new test data and enables `preservePackages`. This test relies on the standard decompiled output comparison.